### PR TITLE
Emit rinfo to server request handlers

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ class Server extends EventEmitter {
   }
   parse(buffer, rinfo) {
     var request = Packet.parse(buffer);
-    this.emit('request', request, this.send.bind(this, rinfo));
+    this.emit('request', request, this.send.bind(this, rinfo), rinfo);
   }
   send(rinfo, message) {
     if(message instanceof Packet)


### PR DESCRIPTION
I'm looking to build a DNS server that has conditional behavior based on the source of DNS requests. Currently, the server in this library doesn't surface the remote information to request handlers. This change allows a handler like `server.on('request', (request, send, rinfo) => {})` and will not break any existing interfaces.