### PR TITLE
Write missing RDATA size for CAA output

### DIFF
--- a/packet.js
+++ b/packet.js
@@ -656,9 +656,12 @@ Packet.Resource.SRV = {
 Packet.Resource.CAA = {
   encode: function(record, writer){
     writer = writer || new Packet.Writer();
-    writer.write(record.flags, 8)
-    writer.write((record.tag.length), 8)
-    var buffer = new Buffer(record.tag + record.value, 'utf8');
+
+    var buffer = new Buffer(record.tag + record.value, "utf8");
+    writer.write(2 + buffer.length, 16);
+    writer.write(record.flags, 8);
+    writer.write(record.tag.length, 8);
+
     buffer.forEach(function(c){
       writer.write(c, 8);
     });


### PR DESCRIPTION
CAA output was missing RDATA size which resulted in malformed output. This PR writes the missing size number to output buffer before the record value.