### PR TITLE
Add support for rfc7871 client subnet

### DIFF
--- a/client/udp.js
+++ b/client/udp.js
@@ -6,7 +6,7 @@ const { debuglog } = require('util');
 const debug = debuglog('dns2');
 
 module.exports = ({ dns = '8.8.8.8', port = 53 } = {}) => {
-  return (name, type = 'A', cls = Packet.CLASS.IN) => {
+  return (name, type = 'A', cls = Packet.CLASS.IN, clientIp) => {
     const query = new Packet();
     query.header.id = (Math.random() * 1e4) | 0;
     query.questions.push({
@@ -14,6 +14,11 @@ module.exports = ({ dns = '8.8.8.8', port = 53 } = {}) => {
       class: cls,
       type: Packet.TYPE[type],
     });
+    if(clientIp) {
+      query.additionals.push(Packet.Resource.EDNS([
+        Packet.Resource.EDNS.ECS(clientIp)
+      ]));
+    };
     const client = new udp.Socket('udp4');
     return new Promise((resolve, reject) => {
       client.once('message', function onMessage(message) {

--- a/example/udp-client-subnet.js
+++ b/example/udp-client-subnet.js
@@ -1,0 +1,11 @@
+const DNS = require('..');
+
+// Lookup directly from ns1.google.com
+const dns = new DNS({nameServers: ['216.239.32.10']});
+
+(async () => {
+  // What is the IP address for google.com if a client in the subnet
+  // '178.67.222.0/24' asks for it?
+  const result = await dns.resolveA('google.com', '178.67.222.0/24');
+  console.log(result.answers);
+})();

--- a/index.js
+++ b/index.js
@@ -32,12 +32,12 @@ class DNS extends EventEmitter {
    * query
    * @param {*} questions 
    */
-  query(name, type, cls) {
+  query(name, type, cls, clientIp) {
     const { port, nameServers } = this;
     const { Client: createResolver } = DNS;
     return Promise.race(nameServers.map(address => {
       const resolve = createResolver({ dns: address, port });
-      return resolve(name, type, cls);
+      return resolve(name, type, cls, clientIp);
     }));
   }
   /**
@@ -46,11 +46,11 @@ class DNS extends EventEmitter {
    * @param {*} type 
    * @param {*} cls 
    */
-  resolve(domain, type = 'ANY', cls = DNS.Packet.CLASS.IN) {
-    return this.query(domain, type, cls);
+  resolve(domain, type = 'ANY', cls = DNS.Packet.CLASS.IN, clientIp) {
+    return this.query(domain, type, cls, clientIp);
   }
-  resolveA(domain) {
-    return this.resolve(domain, 'A');
+  resolveA(domain, clientIp) {
+    return this.resolve(domain, 'A', undefined, clientIp);
   }
   resolveAAAA(domain) {
     return this.resolve(domain, 'AAAA');

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -19,6 +19,14 @@ BufferWriter.prototype.write = function(d, size){
 };
 
 /**
+ * [writeBuffer description]
+ * @param {[type]} b [description]
+ */
+BufferWriter.prototype.writeBuffer = function(b) {
+  this.buffer = this.buffer.concat(b.buffer);
+}
+
+/**
  * [toBuffer description]
  * @return {[type]} [description]
  */

--- a/test/index.js
+++ b/test/index.js
@@ -186,3 +186,15 @@ test('Packet#encode array of character strings', function () {
 
   assert.equal(Packet.parse(response.toBuffer()).answers[0].data, dkim.join(''))
 });
+
+test('EDNS.ECS#encode', function () {
+  var query = new Packet.Resource.EDNS([
+    new Packet.Resource.EDNS.ECS('10.11.12.13/24')
+  ]);
+
+  let b = Packet.Resource.encode(query)
+  assert.deepEqual(b, Buffer.from([
+    0x00, 0x00, 0x29, 0x02, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x0c, 0x00, 0x08, 0x00, 0x08, 0x00,
+    0x01, 0x18, 0x00, 0x0a, 0x0b, 0x0c, 0x0d]))
+})


### PR DESCRIPTION
This PR adds support for Client subnet in DNS queries. This allows the DNS query to specify the ip subnet of the network that originated the DNS query. See example/udp-client-subnet.js for an example of how to use it.

I added the clientIp as one more parameter to resolveA, resolve and query. I do not want to add it to the constructor (along with dns and port), since I want to fire off a lot of requests to the same dns server but with different clientIp for each request. Let me know if you prefer to specify clientIp some other way. 

I tried adding clientIp support to the tcp client as well, but I couldn't find a DoT server that seemed to support it.

I have tried my best to write the code in the same style as the existing code.

