### PR TITLE
Fixed error when dns is passed as array

### DIFF
--- a/client/udp.js
+++ b/client/udp.js
@@ -28,7 +28,18 @@ module.exports = ({ dns = '8.8.8.8', port = 53 } = {}) => {
         resolve(response);
       });
       debug('send', dns, query.toBuffer());
-      client.send(query.toBuffer(), port, dns, err => err && reject(err));
+      
+      if(Array.isArray(dns))
+      {
+        for(const _dns of dns)
+        {
+          client.send(query.toBuffer(), port, _dns, err => err && reject(err));
+        }
+      }
+      else
+      {
+         client.send(query.toBuffer(), port, dns, err => err && reject(err));
+      }
     });
   }
 };


### PR DESCRIPTION
the nameServers option is an Array and it doesn't accept a string.
When passed to the UDP client as an Array it fails as the send method expects a string.

Fixed it to handle both.