### PR TITLE
Feature: combined server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,25 +124,41 @@ const dns2 = require('dns2');
 
 const { Packet } = dns2;
 
-const server = dns2.createUDPServer((request, send, rinfo) => {
-  const response = Packet.createResponseFromRequest(request);
-  const [ question ] = request.questions;
-  const { name } = question;
-  response.answers.push({
-    name,
-    type: Packet.TYPE.A,
-    class: Packet.CLASS.IN,
-    ttl: 300,
-    address: '8.8.8.8'
-  });
-  send(response);
+const server = dns2.createServer({
+  udp: true,
+  handle: (request, send, rinfo) => {
+    const response = Packet.createResponseFromRequest(request);
+    const [ question ] = request.questions;
+    const { name } = question;
+    response.answers.push({
+      name,
+      type: Packet.TYPE.A,
+      class: Packet.CLASS.IN,
+      ttl: 300,
+      address: '8.8.8.8'
+    });
+    send(response);
+  }
 });
 
 server.on('request', (request, response, rinfo) => {
   console.log(request.header.id, request.questions[0]);
 });
 
-server.listen(5333);
+server.on('listening', () => {
+  console.log(server.address());
+});
+
+server.on('close', () => {
+  console.log('server closed');
+});
+
+server.listen({
+  udp: 5333
+});
+
+// eventually
+server.close();
 ```
 
 Then you can test your DNS server:

--- a/example/server/dns.js
+++ b/example/server/dns.js
@@ -1,0 +1,46 @@
+const dns = require('../..');
+const path = require('path');
+const fs = require('fs');
+
+const { Packet } = dns;
+
+// Create a SSL enabled server
+const server = dns.createServer({
+  udp : true,
+  tcp : true,
+  doh : {
+    ssl  : true,
+    cert : fs.readFileSync(path.join(__dirname, 'server.crt')),
+    key  : fs.readFileSync(path.join(__dirname, 'secret.key')),
+  },
+});
+
+// Handle the incomming request (same style as both UDP and TCP server)
+server.on('request', (request, send, client) => {
+  const response = Packet.createResponseFromRequest(request);
+  const [ question ] = request.questions;
+  const { name } = question;
+  response.answers.push({
+    name,
+    type    : Packet.TYPE.A,
+    class   : Packet.CLASS.IN,
+    ttl     : 300,
+    address : '1.1.1.1',
+  });
+  send(response);
+});
+
+(async() => {
+  const closed = new Promise(resolve => process.on('SIGINT', resolve));
+  await server.listen({
+    doh : 8443,
+    udp : 5333,
+    tcp : 5334,
+  });
+  console.log('Listening.');
+  console.log(server.addresses());
+  await closed;
+  process.stdout.write('\n');
+  await server.close();
+  console.log('Closed.');
+})();

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const {
   createTCPServer,
   createUDPServer,
   createDOHServer,
+  createServer,
 } = require('./server');
 const EventEmitter = require('events');
 
@@ -84,6 +85,7 @@ DNS.DOHServer = DOHServer;
 DNS.createUDPServer = createUDPServer;
 DNS.createTCPServer = createTCPServer;
 DNS.createDOHServer = createDOHServer;
+DNS.createServer = createServer;
 
 DNS.TCPClient = require('./client/tcp');
 DNS.DOHClient = require('./client/doh');

--- a/server/dns.js
+++ b/server/dns.js
@@ -1,0 +1,91 @@
+const EventEmitter = require('events');
+const DOHServer = require('./doh');
+const TCPServer = require('./tcp');
+const UDPServer = require('./udp');
+
+class DNSServer extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    this.servers = {};
+    if (options.doh) {
+      this.servers.doh = (new DOHServer(options.doh))
+        .on('error', error => this.emit('error', error, 'doh'));
+    }
+    if (options.tcp) {
+      this.servers.tcp = (new TCPServer())
+        .on('error', error => this.emit('error', error, 'tcp'));
+    }
+    if (options.udp) {
+      this.servers.udp = (new UDPServer(typeof options.udp === 'object' ? options.udp : undefined))
+        .on('error', error => this.emit('error', error, 'udp'));
+    }
+    const servers = Object.values(this.servers);
+    this.closed = Promise.all(
+      servers.map(server => new Promise(resolve => server.once('close', resolve))),
+    ).then(() => {
+      this.emit('close');
+    });
+
+    this.listening = Promise.all(
+      servers.map(server => new Promise(resolve => server.once('listening', resolve))),
+    ).then(() => {
+      const addresses = this.addresses();
+      this.emit('listening', addresses);
+      return addresses;
+    });
+
+    const emitRequest = (request, send, client) => this.emit('request', request, send, client);
+    for (const server of servers) {
+      server.on('request', emitRequest);
+    }
+
+    if (options.handle) {
+      this.on('request', options.handle.bind(options));
+    }
+  }
+
+  addresses() {
+    const addresses = {};
+    const { udp, tcp, doh } = this.servers;
+    if (udp) {
+      addresses.udp = udp.address();
+    }
+    if (tcp) {
+      addresses.tcp = tcp.address();
+    }
+    if (doh) {
+      addresses.doh = doh.address();
+    }
+    return addresses;
+  }
+
+  listen(ports = {}) {
+    const { udp, tcp, doh } = this.servers;
+    if (udp) {
+      udp.listen(ports.udp);
+    }
+    if (tcp) {
+      tcp.listen(ports.tcp);
+    }
+    if (doh) {
+      doh.listen(ports.doh);
+    }
+    return this.listening;
+  }
+
+  close() {
+    const { doh, udp, tcp } = this.servers;
+    if (udp) {
+      udp.close();
+    }
+    if (tcp) {
+      tcp.close();
+    }
+    if (doh) {
+      doh.close();
+    }
+    return this.closed;
+  }
+}
+
+module.exports = DNSServer;

--- a/server/doh.js
+++ b/server/doh.js
@@ -38,7 +38,7 @@ class Server extends EventEmitter {
 
   async handleRequest(client, res) {
     const { method, url, headers } = client;
-    const { pathname, query } = new URL(url, 'http://unused/');
+    const { pathname, searchParams: query } = new URL(url, 'http://unused/');
     const { cors } = this;
     if (cors === true) {
       res.setHeader('Access-Control-Allow-Origin', '*');
@@ -77,7 +77,7 @@ class Server extends EventEmitter {
     let queryData;
     if (method === 'GET') {
       // Parse query string for the request data
-      const { dns } = query;
+      const dns = query.get('dns');
       if (!dns) {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.write('400 Bad Request: No query defined\n');

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const UDPServer = require('./udp');
 const TCPServer = require('./tcp');
 const DOHServer = require('./doh');
+const DNSServer = require('./dns');
 
 const createUDPServer = options => {
   return new UDPServer(options);
@@ -14,11 +15,17 @@ const createDOHServer = options => {
   return new DOHServer(options);
 };
 
+const createServer = options => {
+  return new DNSServer(options);
+};
+
 module.exports = {
   UDPServer,
   TCPServer,
   DOHServer,
+  DNSServer,
   createTCPServer,
   createUDPServer,
   createDOHServer,
+  createServer,
 };


### PR DESCRIPTION
I have been use `node-dns` as a catch-all implementation for tests, offering tcp, udp and doh endpoints.

This PR adds similarly a single server implementation that can start and close `tcp`, `udp` and `doh` servers with a combined statement.

In the process this PR normalizes the API for the `doh` server, making sure that the `error`, `close` and `listening` events are propagated and that a `doh` server has a `.close()` and `.address()` operation. 2230b8c82cf2b6f2117eca640ea9881222306f29

To make the tests work, I added a purposefully undocumented `http` option to `doh` that allows to make `doh` queries against a test localhost server. 0a5925c88d9a89947e8d73787f7ac6fb5d853d6e

_Note: This is based on #49 and contains tests for it._