### PR TITLE
Serial test execution

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,27 +1,34 @@
 const { inspect } = require('util');
+
+let previous = Promise.resolve();
+
 /**
  * super tiny testing framework
  *
  * @author Liu song <hi@lsong.org>
  * @github https://github.com/song940
  */
-const test = async(title, fn) => {
-  try {
-    await fn();
-    console.log(color(` ✔  ${title}`, 32));
-  } catch (err) {
-    console.error(color(` ✘  ${title}`, 31));
-    console.log();
-    console.log(color(`   ${err.name}: ${err.message}`, 31));
-    console.error(color(`   expected: ${inspect(err.expected)}`, 32));
-    console.error(color(`     actual: ${inspect(err.actual)}`, 31));
-    console.log();
-    process.exit(1);
-  }
+const test = (title, fn) => {
+  previous = previous.then(async() => {
+    try {
+      await fn();
+      console.log(color(` ✔  ${title}`, 32));
+    } catch (err) {
+      console.error(color(` ✘  ${title}`, 31));
+      console.log();
+      console.log(color(`   ${err.name}: ${err.message}`, 31));
+      console.error(color(`   expected: ${inspect(err.expected)}`, 32));
+      console.error(color(`     actual: ${inspect(err.actual)}`, 31));
+      console.log(err.stack);
+      console.log();
+      process.exit(1);
+    }
+  });
+  return previous;
 };
 
 function color(str, c) {
-  return '\x1b[' + c + 'm' + str + '\x1b[0m';
+  return `\x1b[${c}m${str}\x1b[0m`;
 }
 
 module.exports = test;


### PR DESCRIPTION
While working on the tests in #50 I was confused by the test output. Also, in order for tests to not influence each other I thought it seems to be a good idea that the tests are executed serially instead of parallel. This PR adds serial execution. I

It also does some minor improvements by showing the stacktrace of an error and fixing the code style to use template strings instead of concatenation.