### PR TITLE
Handle & report server request errors as 'requestError' events

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ server.on('request', (request, response, rinfo) => {
   console.log(request.header.id, request.questions[0]);
 });
 
+server.on('requestError', (error) => {
+  console.log('Client sent an invalid request', error);
+});
+
 server.on('listening', () => {
   console.log(server.address());
 });

--- a/server/dns.js
+++ b/server/dns.js
@@ -35,8 +35,10 @@ class DNSServer extends EventEmitter {
     });
 
     const emitRequest = (request, send, client) => this.emit('request', request, send, client);
+    const emitRequestError = (error) => this.emit('requestError', error);
     for (const server of servers) {
       server.on('request', emitRequest);
+      server.on('requestError', emitRequestError);
     }
 
     if (options.handle) {

--- a/server/tcp.js
+++ b/server/tcp.js
@@ -11,9 +11,13 @@ class Server extends tcp.Server {
   }
 
   async handle(client) {
-    const data = await Packet.readStream(client);
-    const message = Packet.parse(data);
-    this.emit('request', message, this.response.bind(this, client), client);
+    try {
+      const data = await Packet.readStream(client);
+      const message = Packet.parse(data);
+      this.emit('request', message, this.response.bind(this, client), client);
+    } catch (e) {
+      this.emit('requestError', e);
+    }
   }
 
   response(client, message) {

--- a/server/udp.js
+++ b/server/udp.js
@@ -20,8 +20,12 @@ class Server extends udp.Socket {
   }
 
   handle(data, rinfo) {
-    const message = Packet.parse(data);
-    this.emit('request', message, this.response.bind(this, rinfo), rinfo);
+    try {
+      const message = Packet.parse(data);
+      this.emit('request', message, this.response.bind(this, rinfo), rinfo);
+    } catch (e) {
+      this.emit('requestError', e);
+    }
   }
 
   response(rinfo, message) {


### PR DESCRIPTION
Fixes #42.

As discussed in that issue, without this change any invalid DNS packet can crash the server, e.g. by sending an empty UDP packet.

With this change, it's reported as a `requestError` event (not an `error` event, so implementers can ignore this without crashing Node.js if they choose to) and the request is safely ignored.

The changeset for DoH may look large, but that's just due to indentation changes - disable whitespace diffs to see the real change.

It might be possible to improve on this by:

* Improving the parser error messages for various relevant cases, to more easily debug issues
* Sending a useful error response back to the client

I don't think either are especially urgent though, whereas it's quite important to ensure that the server doesn't crash completely when sent trivially invalid input.