### PR TITLE
Fix minor typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ server.on('request', (request, response, rinfo) => {
 });
 
 server.on('listening', () => {
-  console.log(server.address());
+  console.log(server.addresses());
 });
 
 server.on('close', () => {


### PR DESCRIPTION
This API was changed from `address` to `addresses` in https://github.com/song940/node-dns/commit/90992f0e53420d9e58d34c10e0aa21d318ea9124, so this example no longer works.