### PR TITLE
Allow configuring the listen address for each inner DNS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ server.on('close', () => {
 });
 
 server.listen({
-  udp: 5333
+  // Optionally specify port and/or address for each server:
+  udp: { port: 5333 }
 });
 
 // eventually

--- a/server/dns.js
+++ b/server/dns.js
@@ -59,17 +59,18 @@ class DNSServer extends EventEmitter {
     return addresses;
   }
 
-  listen(ports = {}) {
-    const { udp, tcp, doh } = this.servers;
-    if (udp) {
-      udp.listen(ports.udp);
+  listen(options = {}) {
+    for (const serverType of Object.keys(this.servers)) {
+      const server = this.servers[serverType];
+      const serverOptions = options[serverType]; // Port or { port, address }
+
+      if (serverOptions && serverOptions.port) {
+        server.listen(serverOptions.port, serverOptions.address);
+      } else {
+        server.listen(serverOptions);
+      }
     }
-    if (tcp) {
-      tcp.listen(ports.tcp);
-    }
-    if (doh) {
-      doh.listen(ports.doh);
-    }
+
     return this.listening;
   }
 

--- a/server/doh.js
+++ b/server/doh.js
@@ -125,8 +125,8 @@ class Server extends EventEmitter {
    * @param {*} port
    * @returns
    */
-  listen(port) {
-    return this.server.listen(port || this.port);
+  listen(port, address) {
+    return this.server.listen(port || this.port, address);
   }
 
   address() {


### PR DESCRIPTION
Fixes #55. Previously when using `DNSServer` each inner server listened only on the default address. That makes behaviour vary according to the system, whether or not IPv6 is available, and whether listening `::1` also listens on `127.0.0.1` automatically.

This PR allows configuring the specific address used, so that you can fix issues like #55 by explicitly listening on `127.0.0.1`, or other addresses.

This was a bit awkward to do with the existing `ports` argument, so there's now two ways to call `listen()`:

```javascript
// The previous API still works:
server.listen({
  tcp: 5333
  udp: 5333
  doh: 5678
});

// But you can also do this too:
server.listen({
  tcp: { port: 5333, address: '127.0.0.1' },
  udp: { port: 5333, address: '127.0.0.1' },
  doh: { port: 5678, address: '127.0.0.1' }
});
```

This is backward-compatible and all optional. It also conveniently gives us an API that can be easily extended to support more per-server options in future, if necessary.