### PR TITLE
fix: ensure compressed ipv6 is valid

### DIFF
--- a/packet.js
+++ b/packet.js
@@ -514,9 +514,10 @@ Packet.Resource.AAAA = {
       length -= 2;
       parts.push(reader.read(16));
     }
-    this.address = parts.map(function(part) {
-      return part > 0 ? part.toString(16) : '';
-    }).join(':');
+    this.address = parts
+      .map(part => part > 0 ? part.toString(16) : '')
+      .join(':')
+      .replace('::::', '::');
     return this;
   },
   encode: function(record, writer) {

--- a/test/index.js
+++ b/test/index.js
@@ -112,7 +112,7 @@ test('Packet#encode', function() {
     type    : Packet.TYPE.AAAA,
     class   : Packet.CLASS.IN,
     ttl     : 300,
-    address : '2001:db8::::ff00:42:8329',
+    address : '2001:db8::ff00:42:8329',
   });
 
   response.answers.push({


### PR DESCRIPTION
closes https://github.com/song940/node-dns/issues/54

BTW, it could be tested in a better way 