### PR TITLE
Fix/decompress ipv6

### DIFF
--- a/packet.js
+++ b/packet.js
@@ -11,8 +11,16 @@ const toIPv6 = buffer => buffer
 
 const fromIPv6 = (address) => {
   const digits = address.split(':');
-  // CAVEAT we have to take into account the extra
-  // space used by the empty string
+  // CAVEAT edge case for :: and IPs starting
+  // or ending by ::
+  if (digits[0] === '') {
+    digits.shift();
+  }
+  if (digits[digits.length - 1] === '') {
+    digits.pop();
+  }
+  // CAVEAT we have to take into account
+  // the extra space used by the empty string
   const missingFields = 8 - digits.length + 1;
   return digits.flatMap((digit) => {
     if (digit === '') {

--- a/packet.js
+++ b/packet.js
@@ -9,6 +9,19 @@ const toIPv6 = buffer => buffer
   .join(':')
   .replace(/\b(?:0+:){1,}/, ':');
 
+const fromIPv6 = (address) => {
+  const digits = address.split(':');
+  // CAVEAT we have to take into account the extra
+  // space used by the empty string
+  const missingFields = 8 - digits.length + 1;
+  return digits.flatMap((digit) => {
+    if (digit === '') {
+      return Array(missingFields).fill('0');
+    }
+    return digit.padStart(4, '0');
+  });
+};
+
 /**
  * [Packet description]
  * @param {[type]} data [description]
@@ -524,7 +537,7 @@ Packet.Resource.AAAA = {
   },
   encode: function(record, writer) {
     writer = writer || new Packet.Writer();
-    const parts = record.address.split(':');
+    const parts = fromIPv6(record.address);
     writer.write(parts.length * 2, 16);
     parts.forEach(function(part) {
       writer.write(parseInt(part, 16), 16);
@@ -874,3 +887,4 @@ Packet.prototype.toBase64URL = function() {
 
 module.exports = Packet;
 module.exports.toIPv6 = toIPv6;
+module.exports.fromIPv6 = fromIPv6;

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,14 @@ test('Package#toIPv6', function() {
   assert.equal(Packet.toIPv6([ 9734, 18176, 12552, 0, 0, 0, 44098, 10984 ]), '2606:4700:3108::ac42:2ae8');
 });
 
+test('Package#fromIPv6', function() {
+  assert.deepEqual(Packet.fromIPv6('2a04:4e42:200::323'), [
+    '2a04', '4e42', '0200', '0', '0', '0', '0', '0323' ]);
+  assert.deepEqual(Packet.fromIPv6('2a03:b0c0:3:d0::13c1:f001'), [ '2a03', 'b0c0', '0003', '00d0', '0', '0', '13c1', 'f001' ]);
+  assert.deepEqual(Packet.fromIPv6('2a00:1450:4003:807::200e'), [ '2a00', '1450', '4003', '0807', '0', '0', '0', '200e' ]);
+  assert.deepEqual(Packet.fromIPv6('2606:4700:3108::ac42:2ae8'), [ '2606', '4700', '3108', '0', '0', '0', 'ac42', '2ae8' ]);
+});
+
 test('Packet#parse', function() {
   const packet = Packet.parse(response);
   assert.equal(packet.questions[0].name, 'www.z.cn');

--- a/test/index.js
+++ b/test/index.js
@@ -98,6 +98,9 @@ test('Package#fromIPv6', function() {
   assert.deepEqual(Packet.fromIPv6('2a03:b0c0:3:d0::13c1:f001'), [ '2a03', 'b0c0', '0003', '00d0', '0', '0', '13c1', 'f001' ]);
   assert.deepEqual(Packet.fromIPv6('2a00:1450:4003:807::200e'), [ '2a00', '1450', '4003', '0807', '0', '0', '0', '200e' ]);
   assert.deepEqual(Packet.fromIPv6('2606:4700:3108::ac42:2ae8'), [ '2606', '4700', '3108', '0', '0', '0', 'ac42', '2ae8' ]);
+  assert.deepEqual(Packet.fromIPv6('::'), [ '0', '0', '0', '0', '0', '0', '0', '0' ]);
+  assert.deepEqual(Packet.fromIPv6('::2606:4700:3108'), [ '0', '0', '0', '0', '0', '2606', '4700', '3108' ]);
+  assert.deepEqual(Packet.fromIPv6('606:4700:3108::'), [ '0606', '4700', '3108', '0', '0', '0', '0', '0' ]);
 });
 
 test('Packet#parse', function() {


### PR DESCRIPTION
This fix will add flexible formatting when responding to compressed IPv6 solving this issue https://github.com/song940/node-dns/issues/78.

All code has been written taking into account this [ RFC.](https://www.rfc-editor.org/rfc/rfc4291.html#page-2)