### PR TITLE
Accurately reflect `server.listen` options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ server.listen({
   udp: { 
     port: 5333,
     address: "127.0.0.1",
-    type: "udp4",  // IPv4 or IPv6 (Must be either "udp4" or "udp6")
   },
   
   // Optionally specify port and/or address for tcp server:


### PR DESCRIPTION
The README says that the `server.listen` options accepts a `type`, but that doesn't appear to be true [after digging into the code](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69779#discussion_r1636488052). This PR updates the README to remove that from the example.