### PR TITLE
Refactor DOHClient URL completion

### DIFF
--- a/example/client/doh.js
+++ b/example/client/doh.js
@@ -20,3 +20,6 @@ const { DOHClient } = require('../..');
 DOHClient({
   dns: 'https://1.0.0.1/dns-query',
 })('cdnjs.com', 'NS').then(console.log);
+DOHClient({
+  dns: '1.0.0.1',
+})('cdnjs.com', 'NS').then(console.log);


### PR DESCRIPTION
Follows #96, cc @lsongdev 

## 📑 Description

- Re-add pathname auto completion, but this time only for input w/o any `/`
  - So `1.0.0.1` and `dns.google` will become `https://1.0.0.1/dns-query` and `https://dns.google/dns-query`
  - But `https://1.0.0.1` will still be `https://1.0.0.1`
- `URL.searchParams` is mutable and manipulatable, we don't need to re-assign a string to `.search`
- ~~Prefer `URL.href` over `URL.toString()`~~
- Passes URL object directly to `http.get`, `https.get`, and `h2.get`
  - All three implementations accept `URL` type; we don't need to convert the URL to a string here.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

