### PR TITLE
ci: add release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: release
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - package.json
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2 # last 2 commits
+      - name: check version change
+        id: check
+        run: |
+          PREV_VERSION=$(git show HEAD^:package.json | jq -r .version)
+          CURR_VERSION=$(jq -r .version package.json)
+          echo "Previous: $PREV_VERSION"
+          echo "Current:  $CURR_VERSION"
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+          echo "version=$CURR_VERSION" >> $GITHUB_OUTPUT
+
+  build:
+    needs: version
+    if: needs.version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - uses: actions/checkout@v6
+      - run: npm ci || npm install
+      - run: npm test
+
+  create-release:
+    needs: [build, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to create tags and releases
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # fetch all tags
+      - id: tag-check
+        run: |
+          TAG="v${{ needs.version.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Git tag and push
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag v${{ needs.version.outputs.version }}
+          git push origin v${{ needs.version.outputs.version }}
+      - name: Create GitHub Release
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.version.outputs.version }}
+          name: ${{ needs.version.outputs.version }}
+          generate_release_notes: false


### PR DESCRIPTION
This PR does:

- ci(release): generate a GitHub release and NPM publish when ALL of the following criteria are met:
  - a PR has merged against master/main
  - the build tests pass
  - the version in package.json has increased

In order for NPM publishing to work, Trusted Publishing has to be set up for the NPM package. @lsongdev, that requires you to make the following edits on the [package settings page](https://www.npmjs.com/package/dns2/access/). The following settings for OIDC / Trusted Publisher need to be:

- Publisher: Github Actions
- Org: lsongdev
- Repository: node-dns
- Workflow filename: release.yml
- Allowed actions: Allow npm publish