### PR TITLE
feat: CAA decode + 3 fixes

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -18,9 +18,12 @@ function BufferReader(buffer, offset) {
  */
 BufferReader.read = function(buffer, offset, length) {
   let a = [];
-  let c = Math.ceil(length / 8);
   let l = Math.floor(offset / 8);
   const m = offset % 8;
+  // Need enough bytes to cover the bit range [offset, offset+length); when the
+  // offset isn't byte-aligned, the read can straddle one more byte than
+  // ceil(length/8) alone accounts for.
+  let c = Math.ceil((length + m) / 8);
   function t(n) {
     const r = [ 0, 0, 0, 0, 0, 0, 0, 0 ];
     for (let i = 7; i >= 0; i--) {

--- a/packet.js
+++ b/packet.js
@@ -844,6 +844,17 @@ Packet.Resource.CAA = {
     });
     return writer.toBuffer();
   },
+  decode: function(reader, length) {
+    this.flags = reader.read(8);
+    const tagLength = reader.read(8);
+    const bytes = [];
+    let remaining = length - 2;
+    while (remaining--) bytes.push(reader.read(8));
+    const buffer = Buffer.from(bytes);
+    this.tag = buffer.slice(0, tagLength).toString('utf8');
+    this.value = buffer.slice(tagLength).toString('utf8');
+    return this;
+  },
 };
 
 /**
@@ -954,9 +965,14 @@ Packet.Reader = BufferReader;
 Packet.Writer = BufferWriter;
 
 Packet.createResponseFromRequest = function(request) {
-  const response = new Packet(request);
-  response.header.qr = 1;
-  response.additionals = [];
+  const response = new Packet();
+  response.header = new Packet.Header({
+    id     : request.header.id,
+    opcode : request.header.opcode,
+    rd     : request.header.rd,
+    qr     : 1,
+  });
+  response.questions = request.questions.slice();
   return response;
 };
 

--- a/server/doh.js
+++ b/server/doh.js
@@ -20,11 +20,11 @@ const decodeBase64URL = str => {
 };
 
 const readStream = stream => new Promise((resolve, reject) => {
-  let buffer = '';
+  const chunks = [];
   stream
     .on('error', reject)
-    .on('data', chunk => { buffer += chunk; })
-    .on('end', () => resolve(buffer));
+    .on('data', chunk => chunks.push(chunk))
+    .on('end', () => resolve(Buffer.concat(chunks)));
 });
 
 class Server extends EventEmitter {

--- a/test/client.js
+++ b/test/client.js
@@ -66,9 +66,6 @@ test('client/udp times out when no matching response arrives', async() => {
   await new Promise(resolve => server.close(resolve));
 });
 
-// createResponseFromRequest mutates the request in place (clears additionals);
-// these tests snapshot relevant fields BEFORE building the response.
-
 test('client/udp sends ECS additional when clientIp is set', async() => {
   const server = createUDPServer();
   let ednsRecord;

--- a/test/packet.js
+++ b/test/packet.js
@@ -607,17 +607,7 @@ test('Packet.Name encode filters empty labels (trailing dot)', function() {
   assert.deepEqual(a, b);
 });
 
-// ---------------------------------------------------------------------------
-// Known issues — these tests express the CORRECT behavior and currently fail.
-// Un-skip after the corresponding source fix lands.
-// ---------------------------------------------------------------------------
-
-test.skip('BUG: Resource#CAA round-trip via Packet.parse', function() {
-  // Packet.Resource.CAA has no decode method, so Packet.Resource.parse calls
-  // `Packet.Resource.CAA.decode.call(...)` which throws TypeError. The outer
-  // section-loop swallows the exception (debug log only), and the answer is
-  // silently dropped. Fix: add a CAA decoder that reads flags, tagLen, tag,
-  // and value, mirroring the encoder layout.
+test('Resource#CAA round-trip via Packet.parse', function() {
   const packet = new Packet();
   packet.header.qr = 1;
   packet.answers.push({
@@ -636,12 +626,7 @@ test.skip('BUG: Resource#CAA round-trip via Packet.parse', function() {
   assert.equal(parsed.answers[0].value, 'letsencrypt.org');
 });
 
-test.skip('BUG: Packet.createResponseFromRequest does not mutate request', function() {
-  // `new Packet(request)` returns the request itself when it's already a
-  // Packet instance, so createResponseFromRequest sets qr=1 and clears
-  // additionals on the ORIGINAL request. Callers reading request fields after
-  // building a response see the mutation. Fix: build a fresh Packet and copy
-  // the needed fields (id, questions) explicitly.
+test('Packet.createResponseFromRequest does not mutate request', function() {
   const request = new Packet();
   request.header.id = 0x1234;
   request.questions.push({ name: 'x.test', type: Packet.TYPE.A, class: Packet.CLASS.IN });
@@ -657,14 +642,7 @@ test.skip('BUG: Packet.createResponseFromRequest does not mutate request', funct
     'request.additionals should not be cleared');
 });
 
-test.skip('BUG: Reader.read across non-aligned multi-byte offsets', function() {
-  // BufferReader.read uses ceil(length/8) to decide how many bytes to fetch,
-  // ignoring the offset-within-byte. When length > 8 bits and the offset isn't
-  // byte-aligned, the read straddles an additional byte that's never fetched,
-  // and the trailing bits read back as 0. This codepath isn't hit by current
-  // production parsers (all multi-byte reads happen at byte-aligned offsets),
-  // but the reader's contract should still hold. Fix: byteCount =
-  // ceil((length + (offset % 8)) / 8).
+test('Reader.read across non-aligned multi-byte offsets', function() {
   // 0xAB=10101011, 0xCD=11001101, 0xEF=11101111
   // After consuming 4 bits, bits 4-19 are: 1011 11001101 1110 = 0xBCDE
   const reader = new Packet.Reader(Buffer.from([ 0xAB, 0xCD, 0xEF ]));

--- a/test/server.js
+++ b/test/server.js
@@ -198,13 +198,7 @@ test('server/doh#GET via DOHClient end-to-end', async() => {
   server.close();
 });
 
-test.skip('BUG: server/doh#POST end-to-end', async() => {
-  // server/doh.js#readStream collects the request body via string
-  // concatenation (`buffer += chunk`), which decodes incoming chunks as utf-8.
-  // Binary DNS payloads contain bytes that aren't valid utf-8 and get mangled,
-  // so Packet.parse throws and the server destroys the socket — the client
-  // sees a "socket hang up". Fix: collect chunks as Buffer (push into an
-  // array, then Buffer.concat on 'end').
+test('server/doh#POST end-to-end', async() => {
   const server = createDOHServer();
   server.on('request', (request, send) => {
     const response = Packet.createResponseFromRequest(request);


### PR DESCRIPTION
- feat: add CAA decoding
- fix: reads across non-aligned bytes,
- fix: avoid mutating in-place requests
- fix: avoid UTF8 corruption